### PR TITLE
#VFB-67-b ESC and Filter buttons get covered by the suggested results

### DIFF
--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import useAutocomplete from '@mui/base/useAutocomplete';
+import { useAutocomplete } from '@mui/base/useAutocomplete';
 import CircularProgress from '@mui/material/CircularProgress';
 import CloseIcon from '@mui/icons-material/Close';
 import { styled } from '@mui/material/styles';
@@ -233,6 +233,10 @@ export default function SearchBuilder(props) {
     }
   }
 
+  const handleFocused = (focused) => {
+    props.setFocused(focused);
+  }
+
   const {
     getRootProps,
     getInputProps,
@@ -250,6 +254,10 @@ export default function SearchBuilder(props) {
     onInputChange : event => handleSearch(event.target.value)
   });
 
+  React.useEffect(() => {
+    handleFocused(focused);
+  }, [focused])
+
   return (
     <Box flexGrow={1}>
       <Box {...getRootProps()}>
@@ -258,7 +266,7 @@ export default function SearchBuilder(props) {
             <Box
               flexWrap='wrap'
               display='flex'
-              padding={1}
+              paddingRight={1}
               gap={1}
             >
               {value.map((option, index) => (
@@ -288,12 +296,6 @@ export default function SearchBuilder(props) {
       </Box>
       {focused && isOpen ? (
         <Listbox
-          sx={{
-            top: {
-              xs: '2.875rem',
-              lg: '2.125rem'
-            }
-          }}
           className='scrollbar'
           {...getListboxProps()}
         >

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useAutocomplete } from '@mui/base/useAutocomplete';
+import useAutocomplete from '@mui/base/useAutocomplete';
 import CircularProgress from '@mui/material/CircularProgress';
 import CloseIcon from '@mui/icons-material/Close';
 import { styled } from '@mui/material/styles';


### PR DESCRIPTION
Issue #VFB-67
Problem: ESC and Filter buttons get covered by the suggested results
Solution:
So the width of the input gets bigger when on focus, and also removed the top property for the Listbox so it will not cover the input with placeholder and the ESC, filter buttons.

<img width="737" alt="image" src="https://github.com/MetaCell/virtual-fly-brain/assets/67194168/152c6ba7-5d5b-4758-8d6c-a08e291ab455">
