### PR TITLE
VFB-110 - Dropdowns in Queries retain previous values

### DIFF
--- a/applications/virtual-fly-brain/client/src/shared/subHeader/QueriesSelection/QueriesSelectionDropdown.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/QueriesSelection/QueriesSelectionDropdown.js
@@ -36,6 +36,7 @@ export const QueriesSelectionDropdown = ({option, selectedOption, goBackToInitia
   
   const popoverOpen = Boolean(popoverAnchorEl);
   const id = popoverOpen ? 'simple-popover' : undefined;
+  console.log("option label: ", option.label)
 
   return (
   <Box
@@ -133,8 +134,12 @@ export const QueriesSelectionDropdown = ({option, selectedOption, goBackToInitia
                 id={id}
                 open={popoverOpen}
                 anchorEl={popoverAnchorEl}
+                disablePortal={true}
                 sx={{
-                  marginTop: "0.5px !important"
+                  marginTop: "1px !important",
+                  '&.MuiPopper-root': {
+                    width: 'calc(100% - 3.5rem)'
+                  }
                 }}
               >
                 <List>

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/QueriesSelection/QueriesSelectionDropdown.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/QueriesSelection/QueriesSelectionDropdown.js
@@ -36,7 +36,6 @@ export const QueriesSelectionDropdown = ({option, selectedOption, goBackToInitia
   
   const popoverOpen = Boolean(popoverAnchorEl);
   const id = popoverOpen ? 'simple-popover' : undefined;
-  console.log("option label: ", option.label)
 
   return (
   <Box
@@ -145,13 +144,11 @@ export const QueriesSelectionDropdown = ({option, selectedOption, goBackToInitia
                 <List>
                   {!option.queries.Queries.length && <ListItem>
                       <ListItemButton onClick={() => goBack(option.short_form )}>
-                      { selectedQueryIndex === option.short_form || selectedQueryIndex === "" ?
-                      <ListItemText primary={`Select query for ${option.label}`}/>
-                      : null }
+                        <ListItemText primary={`Select query for ${option.label}`}/>
                       </ListItemButton>
                     </ListItem>
                   }
-                  { option.queries?.Queries?.map((query, index) => (selectedQueryIndex === option.short_form || selectedQueryIndex === "" )&& (<ListItem key={query.short_form+index}>
+                  { option.queries?.Queries?.map((query, index) => (<ListItem key={query.short_form+index}>
                     <ListItemButton onClick={() => handleSelect(query, option)}>
                       <ListItemText primary={query.label} />
                     </ListItemButton>

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/QueriesSelection/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/QueriesSelection/index.js
@@ -25,22 +25,6 @@ export const QueriesSelection = ({ checkResults, handleQueryDeletion, recentSear
     setSelectedOption(updateSelection)
   }
 
-  const handleSelect = (option, query) => {
-    let count = 0;
-    if ( query.queries?.Examples && !selectedOption[query.short_form]) {
-      count = Object.keys(query.queries?.Examples)?.length;
-    }
-    Object.keys(selectedOption)?.forEach( o => {
-      if ( typeof selectedOption[o] === 'object' ) {
-        count = count + ( selectedOption[o].count || 0 )
-      } 
-    })
-    let updatedSelectedOption = {...selectedOption, [query.short_form]: option, count : count};
-    updatedSelectedOption[query.short_form].count =  Object.keys(query.queries?.Examples)?.length || 0;
-    setSelectedOption(updatedSelectedOption)
-    setPopoverAnchorEl(null);
-  };
-
   const goBackToInitialState = (short_form) => {
     setSelectedQueryIndex("")
     let updatedSelectedOption = {...selectedOption, [short_form]: true, count : selectedOption.count - selectedOption[short_form].count};


### PR DESCRIPTION
Issue #VFB-110
Problem: Dropdowns in Queries retain previous values
Solution: 
So dropdown menu opening on different positions was handled by making it fullwidth and by deleting unnecessary check that was creating this issue 
<img width="644" alt="image" src="https://github.com/MetaCell/virtual-fly-brain/assets/67194168/93f532f2-f608-4415-94ff-4f18298759f9">
