### PR TITLE
VFB 134 - Upgrade vfbquery to 2.11. Needed since data coming back fr…

### DIFF
--- a/applications/virtual-fly-brain/backend/requirements.txt
+++ b/applications/virtual-fly-brain/backend/requirements.txt
@@ -12,4 +12,4 @@ Flask == 2.2.2
 psycopg2-binary
 gunicorn==20.1.0
 flask_cors==3.0.10
-vfbquery==0.2.8
+vfbquery==0.2.11


### PR DESCRIPTION
This PR is for issue VFB-134 from the Jira Board. Upgrades vfbquery to 2.11. Needed since data coming back from SOLR changed, and this new version handles parsing that new data.

Tested locally using http://localhost:3300/?id=VFB_00030624 or any other ID. Prior to the fix, retrieving the template ID was broken, with new release the template IDs are fine. 

To install changes locally:
- If working from conda environment, activate it and update python libraries `applications/virtual-fly-brain/backend/requirements.txt `with command . 
`pip install -r requirements.txt`