### PR TITLE
#VFB-135 - Refactor more updates out of the ThreeDCanvas into redux store

### DIFF
--- a/applications/virtual-fly-brain/client/src/components/TermInfo.js
+++ b/applications/virtual-fly-brain/client/src/components/TermInfo.js
@@ -534,7 +534,7 @@ const TermInfo = ({ open, setOpen }) => {
                           <Button  onClick={(event) => handleMeshVisibility()}>
                           { getInstance()?.simpleInstance?.visibility ? <ArViewOff /> : <ArView /> }                          </Button>
                         </Tooltip>
-                        { termInfoData?.metadata?.SuperTypes?.find( s => s === NEURON) ?
+                        { termInfoData?.metadata?.SuperTypes?.find( s => s.toLowerCase() === NEURON.toLowerCase()) ?
                         <Tooltip title={getInstance()?.skeleton?.[SKELETON]?.visible ? "Disable 3D Skeleton" : "Enable 3D Skeleton"}>
                           <Button onClick={(event) => handleSkeleton(event)}>
                             {getInstance()?.skeleton?.[SKELETON]?.visible ? <SkeletonOff /> : <SkeletonOn /> }
@@ -542,7 +542,7 @@ const TermInfo = ({ open, setOpen }) => {
                         </Tooltip>
                         :
                         null}
-                        { termInfoData?.metadata?.SuperTypes?.find( s => s === NEURON) ?
+                        { termInfoData?.metadata?.SuperTypes?.find( s => s.toLowerCase() === NEURON.toLowerCase()) ?
                         <Tooltip title={getInstance()?.skeleton?.[CYLINDERS]?.visible ? "Show 3D Lines Skeleton" : "Show 3D Cylinder Skeleton"}>
                           <Button onClick={(event) => handleCylinder(event)}>
                           {getInstance()?.skeleton?.[CYLINDERS]?.visible ? <CylinderOff id={SKELETON} /> : <CylinderOn id={CYLINDERS}/> }

--- a/applications/virtual-fly-brain/client/src/network/query.js
+++ b/applications/virtual-fly-brain/client/src/network/query.js
@@ -38,13 +38,13 @@ export const get_instance = async (short_form) => {
 }
 
 export const get_3d_mesh = async (targetInstance) => {
-  let response = await fetch(targetInstance?.metadata?.Images?.[Object.keys(targetInstance?.metadata?.Images)[0]][0].obj)
+  let response = await fetch(targetInstance?.Images?.[Object.keys(targetInstance?.Images)[0]][0].obj)
     .then(response => response.text())
     .then(base64Content => {
       const instance = {
         "eClass": "SimpleInstance",
-        "id": targetInstance?.metadata?.Id,
-        "name": targetInstance?.metadata?.Name,
+        "id": targetInstance?.Id,
+        "name": targetInstance?.Name,
         "type": { "eClass": "SimpleType" },
         "visualValue": {
           "eClass": Resources.OBJ,

--- a/applications/virtual-fly-brain/client/src/reducers/InstancesReducer.js
+++ b/applications/virtual-fly-brain/client/src/reducers/InstancesReducer.js
@@ -4,17 +4,33 @@ import { loadInstances, getProxyInstances } from './../utils/instancesHelper'
 import { SkeletonOff } from '../icons';
 import { on } from 'events';
 import { find } from '@nosferatu500/react-sortable-tree';
+import { get3DMesh } from './actions/instances';
 
 export const initialStateInstancesReducer = {
   allPotentialInstances : [],
   allLoadedInstances : [],
   threeDObjects : [],
+  mappedCanvasData : [],
   focusedInstance : "",
   event : {},
   isLoading: false,
   launchTemplate : null,
   error: false
 };
+
+const getMappedCanvasData = (loadedInstances) => {
+  let updatedCanvasData = loadedInstances?.filter( m => m?.simpleInstance )?.map( instance => {
+    let { color, visibility, id } = instance.simpleInstance;
+    return {
+      instancePath : id,
+      visibility,
+      color,
+      selected : instance.selected
+    }
+  })
+
+  return updatedCanvasData;
+}
 
 const InstancesReducer = (state = initialStateInstancesReducer, response) => {
   switch (response.type) {
@@ -53,6 +69,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
         })
       }
       let loadedInstances = state.allLoadedInstances?.find( i => i?.metadata?.Id === response.payload.Id ) ? [...state.allLoadedInstances] : [...state.allLoadedInstances, newInstance]
+
       return Object.assign({}, state, {
           allLoadedInstances: loadedInstances,
           focusedInstance : loadedInstances?.find( i => i?.metadata?.Id === response.payload.Id ),
@@ -77,6 +94,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
 
         return Object.assign({}, state, {
           allLoadedInstances: loadedInstances,
+          mappedCanvasData : getMappedCanvasData(loadedInstances),
           threeDObjects : matchObjects,
           focusedInstance : focusedInstance,
           event : { action : getInstancesTypes.UPDATE_INSTANCES, id : response.payload.query, trigger : Date.now()},
@@ -90,6 +108,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
         if ( matchInstance?.simpleInstance ) matchInstance.simpleInstance.visibility = true;
         return Object.assign({}, state, {
           allLoadedInstances: allLoadedInstances,
+          mappedCanvasData : getMappedCanvasData(allLoadedInstances),
           event : { action : getInstancesTypes.UPDATE_INSTANCES, id : response.payload.id, trigger : Date.now()},
           isLoading: false
         })
@@ -101,6 +120,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
         if ( matchInstance?.simpleInstance ) matchInstance.simpleInstance.visibility = false;
         return Object.assign({}, state, {
           allLoadedInstances: allLoadedInstances,
+          mappedCanvasData : getMappedCanvasData(allLoadedInstances),
           event : { action : getInstancesTypes.UPDATE_INSTANCES, id : response.payload.id, trigger : Date.now()},
           isLoading: false
         })
@@ -111,6 +131,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
         matchSimpleInstance.visibility = true;
         return Object.assign({}, state, {
           allLoadedInstances: allLoadedInstances,
+          mappedCanvasData : getMappedCanvasData(allLoadedInstances),
           event : { action : getInstancesTypes.UPDATE_INSTANCES, id : response.payload.id, trigger : Date.now()},
           isLoading: false
         })
@@ -121,6 +142,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
         matchSimpleInstance.visibility = false;
         return Object.assign({}, state, {
           allLoadedInstances: allLoadedInstances,
+          mappedCanvasData : getMappedCanvasData(allLoadedInstances),
           event : { action : getInstancesTypes.UPDATE_INSTANCES, id : response.payload.id, trigger : Date.now()},
           isLoading: false
         })
@@ -141,6 +163,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
         return Object.assign({}, state, {
           allLoadedInstances : allLoadedInstances,
           threeDObjects : threeDObjects, 
+          mappedCanvasData : getMappedCanvasData(allLoadedInstances),
           event : { action : getInstancesTypes.UPDATE_INSTANCES, id : response.payload.id, trigger : Date.now()},
           isLoading: false
         })
@@ -177,6 +200,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
         return Object.assign({}, state, {
           allLoadedInstances:allLoadedInstances,
           threeDObjects : threeDObjects,
+          mappedCanvasData : getMappedCanvasData(allLoadedInstances),
           event : { action : getInstancesTypes.UPDATE_INSTANCES, id : response.payload.id, trigger : Date.now()},
           isLoading: false
         })
@@ -196,6 +220,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
 
         return Object.assign({}, state, {
           allLoadedInstances : loadedInstances,
+          mappedCanvasData : getMappedCanvasData(loadedInstances),
           event : { action : getInstancesTypes.UPDATE_INSTANCES, id : response.payload.id, trigger : Date.now()},
           isLoading: false
         })}
@@ -237,6 +262,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
         return Object.assign({}, state, {
           threeDObjects : threeDObjects,
           allLoadedInstances : allLoadedInstances,
+          mappedCanvasData : getMappedCanvasData(allLoadedInstances),
           event : { 
             action : getInstancesTypes.UPDATE_INSTANCES,
             id : response.payload.id,
@@ -286,7 +312,7 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
           matchObject.visible = false;
         }
         return Object.assign({}, state, {
-          threeDObjects : threeDObjects, 
+          threeDObjects : threeDObjects,
           allLoadedInstances : allLoadedInstances,
           event : { action : getInstancesTypes.UPDATE_SKELETON, mode : SKELETON, id : response.payload.id, visible : false, trigger : Date.now()},
           isLoading: false

--- a/applications/virtual-fly-brain/client/src/reducers/actions/instances.js
+++ b/applications/virtual-fly-brain/client/src/reducers/actions/instances.js
@@ -175,6 +175,8 @@ export const getInstanceByID = async (queryId) => {
   }
 
   store.dispatch(getInstancesSuccess(response))
+
+  get3DMesh(response)
 }
 
 export const get3DMesh = async (instance) => {


### PR DESCRIPTION
Moves out more updates out of the THREEDCanvas into redux store, mappedCanvasData previously in THREEDCanvas is now on redux store. Retrieving 3D meshes for new IDs now happens immediately after retrieving the metadata for the ID, [see here](https://github.com/MetaCell/virtual-fly-brain/compare/development...feature/vfb-135-fixes?expand=1#diff-e76c80886d7976a42172c9d26c6e3d730e5fee98b369bafd15a74ce203b3cf3dR179), this way the THREEDCanvas no longer calls this action. 

Only two updates are left that are handled by the canvas.
1. This one, [FOCUS_INSTANCE](https://github.com/MetaCell/virtual-fly-brain/blob/feature/vfb-135-fixes/applications/virtual-fly-brain/client/src/components/ThreeDCanvas.js#L67), handles resetting the camera. Issue VFB-136 should help us get rid of need to call camera handler like this.
2. [UPDATE_SKELETON](https://github.com/MetaCell/virtual-fly-brain/blob/feature/vfb-135-fixes/applications/virtual-fly-brain/client/src/components/ThreeDCanvas.js#L69), we use our own library to parse an SWC file here. If we want to get rid of it, we need geppetto-meta to handle parsing/loading SWC files.

Tested:
Locally loading multiple IDs by parameter and search. Same behavior as in dev deployment.