### PR TITLE
#VFB-137 - Aligns chip colors with ones in production

### DIFF
--- a/applications/virtual-fly-brain/client/src/components/TermInfo.js
+++ b/applications/virtual-fly-brain/client/src/components/TermInfo.js
@@ -582,7 +582,7 @@ const TermInfo = ({ open, setOpen }) => {
                   <Typography>General Information</Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <GeneralInformation data={termInfoData?.metadata} classes={classes} />
+                  <GeneralInformation data={termInfoData} classes={classes} />
                 </AccordionDetails>
               </Accordion>
 

--- a/applications/virtual-fly-brain/client/src/components/TermInfo/GeneralInformation.js
+++ b/applications/virtual-fly-brain/client/src/components/TermInfo/GeneralInformation.js
@@ -68,7 +68,7 @@ const GeneralInformation = ({data, classes}) => {
               <Typography sx={classes.heading}>Tags</Typography>
                 <Box display='flex' gap={'0.188rem'}>
                   {
-                    data?.metadata?.Tags?.map((tag, i) => ( <Chip key={tag} sx={{backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color }} label={tag} /> ) )
+                    data?.metadata?.Tags?.map((tag, i) => ( <Chip key={tag} sx={{backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color}} label={tag} /> ) )
                   }
                 { data?.metadata?.Tags?.length > 2 && <Chip label={`+${data?.metadata?.Tags?.length - 2}`} /> }
               </Box>

--- a/applications/virtual-fly-brain/client/src/components/TermInfo/GeneralInformation.js
+++ b/applications/virtual-fly-brain/client/src/components/TermInfo/GeneralInformation.js
@@ -15,7 +15,7 @@ const {
   descriptionBg
 } = vars;
 
-const chipColor = [ 'primary', 'secondary' ];
+const facets_annotations_colors = require("../../components/configuration/VFBColors").facets_annotations_colors;
 
 const GeneralInformation = ({data, classes}) => {
   const [ toggleReadMore, setToggleReadMore ] = useState( false );
@@ -44,7 +44,7 @@ const GeneralInformation = ({data, classes}) => {
             <TerminfoSlider
               allowFullscreen
               setFullScreen={setFullScreen}
-              examples={data?.Images ? data?.Images : data?.Examples}
+              examples={data?.metadata?.Images ? data?.metadata?.Images : data?.metadata?.Examples}
             />
           </Box>
         </Grid>
@@ -68,7 +68,7 @@ const GeneralInformation = ({data, classes}) => {
               <Typography sx={classes.heading}>Tags</Typography>
                 <Box display='flex' gap={'0.188rem'}>
                   {
-                    data?.metadata?.Tags?.map((tag, i) => <Chip key={tag} color={chipColor[i]} label={tag} />)
+                    data?.metadata?.Tags?.map((tag, i) => ( <Chip key={tag} sx={{backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color }} label={tag} /> ) )
                   }
                 { data?.metadata?.Tags?.length > 2 && <Chip label={`+${data?.metadata?.Tags?.length - 2}`} /> }
               </Box>
@@ -137,7 +137,7 @@ const GeneralInformation = ({data, classes}) => {
       </Grid>
 
       {fullScreen && (
-        <FullScreenViewer open={ fullScreen } onClose={ () => setFullScreen( false ) } images={data?.Images ? data?.Images : data?.Examples}>
+        <FullScreenViewer open={ fullScreen } onClose={ () => setFullScreen( false ) } images={data?.metadata?.Images ? data?.metadata?.Images : data?.metadata?.Examples}>
           <Button sx={ { position: 'absolute', zIndex: 9, gap: '0.25rem', right: '1.75rem', top: '1.75rem' } } variant="contained" color="info">
             <Compare />
             Compare images with current

--- a/applications/virtual-fly-brain/client/src/components/VFBListViewer/ListViewerControlsMenu.js
+++ b/applications/virtual-fly-brain/client/src/components/VFBListViewer/ListViewerControlsMenu.js
@@ -153,7 +153,7 @@ class ListViewerControlsMenu extends Component {
     let updatedButtons = buttons.map((button, index) => {
       const updatedButton = {...button}
       if ( self.props.allLoadedInstances?.find( i => i.metadata?.Id == self.props.instance) !== undefined ) {
-        updatedButton.activeColor = RGBAToHexA(self.props.allLoadedInstances?.find( i => i.metadata?.Id == self.props.instance)?.color);
+        updatedButton.activeColor = RGBAToHexA(self.props.allLoadedInstances?.find( i => i.metadata?.Id == self.props.instance)?.simpleInstance?.color);
         updatedButton.list.map(item => {
           // Iterate through button list in configuration, store new configuration in 'list' array
           this.iterateConfList(list, item);

--- a/applications/virtual-fly-brain/client/src/components/configuration/TermInfo/TermInfo.js
+++ b/applications/virtual-fly-brain/client/src/components/configuration/TermInfo/TermInfo.js
@@ -1,8 +1,8 @@
 const ribbonConfiguration = {
-    heatLevels : 32,
-    rgbColor : [1, 191, 254]
+    heatLevels: 32,
+    rgbColor: [1, 191, 254]
 }
 
 module.exports = {
     ribbonConfiguration
-};
+}

--- a/applications/virtual-fly-brain/client/src/components/configuration/VFBColors.js
+++ b/applications/virtual-fly-brain/client/src/components/configuration/VFBColors.js
@@ -1,5 +1,5 @@
 const facets_annotations_colors = {
-    Default : {
+    default : {
         color : "#A04E4E"
     },
     Adult: {

--- a/applications/virtual-fly-brain/client/src/components/configuration/VFBColors.js
+++ b/applications/virtual-fly-brain/client/src/components/configuration/VFBColors.js
@@ -1,0 +1,297 @@
+const facets_annotations_colors = {
+    Default : {
+        color : "#A04E4E"
+    },
+    Adult: {
+        color: "#ffffb3"
+    },
+    Anatomy: {
+        color: "#33a02c"
+    },
+    Cholinergic: {
+        color: "#bebada"
+    },
+    Clone: {
+        color: "#cab2d6"
+    },
+    Cluster: {
+        color: "#ffed6f"
+    },
+    Dopaminergic: {
+        color: "#fdbf6f"
+    },
+    Expression_pattern: {
+        color: "#b3de69"
+    },
+    Expression_pattern_fragment: {
+        color: "#6a3d9a"
+    },
+    GABAergic: {
+        color: "#1f78b4"
+    },
+    Ganglion: {
+        color: "#ff7f00"
+    },
+    Glutamatergic: {
+        color: "#b2df8a"
+    },
+    Larva: {
+        color: "#ccebc5"
+    },
+    Motor_neuron: {
+        color: "#e31a1c"
+    },
+    Muscle: {
+        color: "#a6cee3"
+    },
+    Nervous_system: {
+        color: "#fdb462"
+    },
+    Neuromere: {
+        color: "#8dd3c7"
+    },
+    Neuron: {
+        color: "#b15928"
+    },
+    Neuron_projection_bundle: {
+        color: "#bc80bd"
+    },
+    Octopaminergic: {
+        color: "#ffff99"
+    },
+    Peptidergic_neuron: {
+        color: "#80b1d3"
+    },
+    Sensory_neuron: {
+        color: "#fb9a99"
+    },
+    Serotonergic: {
+        color: "#d9d9d9"
+    },
+    Synaptic_neuropil_block: {
+        color: "#fccde5"
+    },
+    Synaptic_neuropil_domain: {
+        color: "#fb8072"
+    },
+    Synaptic_neuropil_subdomain: {
+        color: "#88ffb3"
+    },
+    Template: {
+        color: "#ff6cc8"
+    },
+    DataSet: {
+        color: "#b700b5"
+    },
+    Synaptic_neuropil: {
+        color: "#00a2aa"
+    },
+    pub: {
+        color: "#0164d8"
+    },
+    License: {
+        color: "#0164d8"
+    },
+    Person: {
+        color: "#023f00"
+    },
+    Glial_cell: {
+        color: "#ff6a3a"
+    },
+    Cell: {
+        color: "#fbcf1d"
+    },
+    Property: {
+        color: "#005f1d"
+    },
+    Resource: {
+        color: "#005f1d"
+    },
+    Site: {
+        color: "#005f1d"
+    },
+    Split: {
+        color: "#e012e3"
+    },
+    Deprecated: {
+        color: "#ff0000"
+    },
+    Gene: {
+        color: "#ffcdd2"
+    },
+    Allele: {
+        color: "#DCEDC8"
+    },
+    FBst: {
+        color: "#E1BEE7"
+    },
+    Insertion: {
+        color: "#D1C4E9"
+    },
+    FB_Reference: {
+        color: "#dcf"
+    },
+    FBcl: {
+        color: "#BBDEFB"
+    },
+    FBtr: {
+        color: "#C5CAE9"
+    },
+    FBpp: {
+        color: "#B3E5FC"
+    },
+    FBab: {
+        color: "#B2EBF"
+    },
+    FBba: {
+        color: "#B2DFDB"
+    },
+    FBte: {
+        color: "#C8E6C9"
+    },
+    FBto: {
+        color: "#fb0"
+    },
+    Transgenic_Construct: {
+        color: "#F8BBD0"
+    },
+    FBmc: {
+        color: "#F0F4C3"
+    },
+    FBms: {
+        color: "#FFF9C4"
+    },
+    FBsf: {
+        color: "#FFECB3"
+    },
+    FBlc: {
+        color: "#FFE0B2"
+    },
+    FBtc: {
+        color: "#FFCCBC"
+    },
+    FBig: {
+        color: "#D7CCC8"
+    },
+    FBgg: {
+        color: "#F5F5D5"
+    },
+    FBhh: {
+        color: "#edb"
+    },
+    FBsn: {
+        color: "#fdc"
+    },
+    FB_Image: {
+        color: "#fe8"
+    },
+    Thermosensory_system: {
+        color: "#AA0000"
+    },
+    Neuroblast: {
+        color: "#8df8f9"
+    },
+    GMC: {
+        color: "#ecf7f7"
+    },
+    Mechanosensory_system: {
+        color: "#00aaaa"
+    },
+    Visual_system: {
+        color: "#0000aa"
+    },
+    Olfactory_system: {
+        color: "#00aa00"
+    },
+    Auditory_system: {
+        color: "#aa00aa"
+    },
+    Gustatory__system: {
+        color: "#aaaa00"
+    },
+    Proprioceptive_system: {
+        color: "#00aaaa"
+    },
+    Chemosensory_system: {
+        color: "#ea9e24"
+    },
+    Hygrosensory_system: {
+        color: "#0000ff"
+    },
+    Nociceptive_system: {
+        color: "#ffa500"
+    },
+    Stage: {
+        color: "#dfe"
+    },
+    Acetylcholine_receptor: {
+        color: "#11bffe"
+    },
+    Calcium_binding: {
+        color: "#11bffe"
+    },
+    Dopamine_receptor: {
+        color: "#11bffe"
+    },
+    Enzyme: {
+        color: "#11bffe"
+    },
+    GABA_receptor: {
+        color: "#11bffe"
+    },
+    Glutamate_receptor: {
+        color: "#11bffe"
+    },
+    GPCR: {
+        color: "#11bffe"
+    },
+    Gustatory_receptor: {
+        color: "#11bffe"
+    },
+    Histamine_receptor: {
+        color: "#11bffe"
+    },
+    Hormone: {
+        color: "#11bffe"
+    },
+    Ion_channel: {
+        color: "#11bffe"
+    },
+    Mechanosensory_ion_channel: {
+        color: "#11bffe"
+    },
+    Neuropeptide: {
+        color: "#11bffe"
+    },
+    Octopamine_receptor: {
+        color: "#11bffe"
+    },
+    Odorant_binding: {
+        color: "#11bffe"
+    },
+    Olfactory_receptor: {
+        color: "#11bffe"
+    },
+    Peptide_or_protein_hormone_receptor: {
+        color: "#11bffe"
+    },
+    Photoreceptor: {
+        color: "#11bffe"
+    },
+    Serotonin_receptor: {
+        color: "#11bffe"
+    },
+    Thermosensory_ion_channel: {
+        color: "#11bffe"
+    },
+    Transcription_factor: {
+        color: "#11bffe"
+    },
+    Tyramine_receptor: {
+        color: "#11bffe"
+    }
+}
+
+module.exports = {
+    facets_annotations_colors
+}

--- a/applications/virtual-fly-brain/client/src/components/queryBuilder/Card.js
+++ b/applications/virtual-fly-brain/client/src/components/queryBuilder/Card.js
@@ -11,19 +11,13 @@ const {
   listHeadingColor,
   whiteColor,
   tabActiveColor,
-  chipGreen,
-  chipOrange,
-  chipRed,
-  chipPink,
   primaryBg,
-  chipYellow,
   secondaryBg,
   outlinedBtnBorderColor,
   outlinedBtnTextColor
 } = vars;
 
-
-const chipColors = [chipRed, chipGreen, chipOrange, chipPink, chipYellow];
+const facets_annotations_colors = require("../configuration/VFBColors").facets_annotations_colors;
 
 const QueryCard = ({ fullWidth, facets_annotation, query }) => {
   const [toggleReadMore, setToggleReadMore] = useState(false);
@@ -269,7 +263,7 @@ const QueryCard = ({ fullWidth, facets_annotation, query }) => {
                   sx={{
                     lineHeight: '140%',
                     fontSize: '0.625rem',
-                    backgroundColor: chipColors[index%(chipColors.length-1)] || chipColors[0]
+                    backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default']?.color
                   }}
                   label={tag} />
                 ))}
@@ -284,7 +278,7 @@ const QueryCard = ({ fullWidth, facets_annotation, query }) => {
                           sx={{
                             lineHeight: '140%',
                             fontSize: '0.625rem',
-                            backgroundColor: chipColors[index%(chipColors.length-1)] || chipColors[0]
+                            backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default']?.color
                           }}
                           label={tag} />
                       ))}

--- a/applications/virtual-fly-brain/client/src/components/queryBuilder/Card.js
+++ b/applications/virtual-fly-brain/client/src/components/queryBuilder/Card.js
@@ -263,7 +263,7 @@ const QueryCard = ({ fullWidth, facets_annotation, query }) => {
                   sx={{
                     lineHeight: '140%',
                     fontSize: '0.625rem',
-                    backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default']?.color
+                    backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color
                   }}
                   label={tag} />
                 ))}
@@ -278,7 +278,7 @@ const QueryCard = ({ fullWidth, facets_annotation, query }) => {
                           sx={{
                             lineHeight: '140%',
                             fontSize: '0.625rem',
-                            backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default']?.color
+                            backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color
                           }}
                           label={tag} />
                       ))}

--- a/applications/virtual-fly-brain/client/src/components/queryBuilder/Filter.js
+++ b/applications/virtual-fly-brain/client/src/components/queryBuilder/Filter.js
@@ -3,22 +3,6 @@ import { CheckBoxDefault, CheckBoxGreen, CheckBoxRed, CleaningServices, FilterIc
 import { Box, Button, Checkbox, FormControlLabel, FormGroup, IconButton, Popper, Typography } from "@mui/material";
 import vars from "../../theme/variables";
 
-const filterChipColors = [
-  '#6D4EA0',
-  '#4E5BA0',
-  '#4E91A0',
-  '#4EA082',
-  '#4EA060',
-  '#68A04E',
-  '#7CA04E',
-  '#A0984E',
-  '#A07A4E',
-  '#A0624E',
-  '#A04E6C',
-  '#994EA0',
-  '#A04E4E'
-];
-
 const DUMMY_FILTERS = [
   {
     id: 0,
@@ -77,7 +61,7 @@ const DUMMY_FILTERS = [
 
 const { primaryBg, outlinedBtnTextColor, bottomNavBg, tabActiveColor, whiteColor, searchHeadingColor } = vars;
 
-const Filter = () => {
+const Filter = (props) => {
   const [filterAnchorEl, setFilterAnchorEl] = React.useState(null);
   const [filtersApplied, setFiltersApplied] = useState(true)
 
@@ -152,12 +136,12 @@ const Filter = () => {
             alignItems: 'flex-start',
             rowGap: 1.5
           }}>
-            {DUMMY_FILTERS.map((filter, index) => (
+            {DUMMY_FILTERS.map((tag, index) => (
               <FormControlLabel sx={{
                 height: '20px',
                 borderRadius: '50px',
                 px: '0.5rem',
-                backgroundColor: filterChipColors[index],
+                backgroundColor: props.facets_annotations_colors[tag.label]?.color,
 
                 '& .MuiCheckbox-root': {
                   marginRight: '0.25rem'
@@ -168,7 +152,7 @@ const Filter = () => {
                   fontSize: '0.625rem'
                 }
 
-              }} key={filter.id} control={<Checkbox checkedIcon={<Tick color={whiteColor} />} icon={<></>} />} label={filter.label} />
+              }} key={tag.id} control={<Checkbox checkedIcon={<Tick color={whiteColor} />} icon={<></>} />} label={tag.label} />
             ))}
           </FormGroup>
         </Box>

--- a/applications/virtual-fly-brain/client/src/components/queryBuilder/History.js
+++ b/applications/virtual-fly-brain/client/src/components/queryBuilder/History.js
@@ -3,13 +3,8 @@ import QueryHeader from "./QueryHeader";
 import { Item } from "./HistoryItem";
 import vars from "../../theme/variables";
 import { Box } from "@mui/material";
-const {
-  chipPink,
-  chipRed,
-  chipGreen,
-  chipYellow,
-  chipOrange
-} = vars;
+
+const facets_annotations_colors = require("../configuration/VFBColors").facets_annotations_colors;
 
 const recentSearch = [
   {
@@ -53,8 +48,6 @@ const recentSearch = [
 ]
 
 const History = () => {
-  const chipColors = [chipRed, chipGreen, chipOrange, chipPink, chipYellow];
-
   return (
     <>
       <QueryHeader title="8 results in history" />
@@ -64,7 +57,7 @@ const History = () => {
           <Item
             key={`recentSearch-${index}`}
             search={search}
-            chipColors={chipColors}
+            chipColors={facets_annotations_colors}
             index={index}
           />
         ))}

--- a/applications/virtual-fly-brain/client/src/components/queryBuilder/Query.js
+++ b/applications/virtual-fly-brain/client/src/components/queryBuilder/Query.js
@@ -69,10 +69,10 @@ const Query = ({ fullWidth, queries }) => {
                 sx={{
                   lineHeight: '0.875rem',
                   fontSize: '0.625rem',
-                  backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color,
+                  backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color,
                   height: '1.25rem',
                   '&:hover': {
-                    backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color
+                    backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color
                   }
                 }}
                 label={tag} />
@@ -96,7 +96,7 @@ const Query = ({ fullWidth, queries }) => {
                         sx={{
                           lineHeight: '140%',
                           fontSize: '0.625rem',
-                          backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color
+                          backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color
                         }}
                         label={tag} />
                     ))}

--- a/applications/virtual-fly-brain/client/src/components/queryBuilder/Query.js
+++ b/applications/virtual-fly-brain/client/src/components/queryBuilder/Query.js
@@ -6,21 +6,9 @@ import QueryHeader from "./QueryHeader";
 import vars from "../../theme/variables";
 import Filter from "./Filter";
 
-const { chipOrange, chipGreen, chipRed, chipPink, chipYellow, headerBorderColor, searchHeadingColor, secondaryBg, listHeadingColor, primaryBg } = vars;
-const chipColors = [chipRed, chipGreen, chipOrange, chipPink, chipYellow];
+const { headerBorderColor, searchHeadingColor, secondaryBg, listHeadingColor, primaryBg } = vars;
+const facets_annotations_colors = require("../configuration/VFBColors").facets_annotations_colors;
 
-const chipsArr = [
-  {
-    id: 0,
-    label: 'Anatomy',
-    color: chipGreen
-  },
-  {
-    id: 1,
-    label: 'Neuron',
-    color: chipOrange
-  }
-];
 
 export const dividerStyle = {
   height: '0.875rem', width: '0.0625rem', background: listHeadingColor, borderRadius: '0.125rem'
@@ -81,10 +69,10 @@ const Query = ({ fullWidth, queries }) => {
                 sx={{
                   lineHeight: '0.875rem',
                   fontSize: '0.625rem',
-                  backgroundColor: chipColors[index%(chipColors.length-1)] || chipColors[0],
+                  backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color,
                   height: '1.25rem',
                   '&:hover': {
-                    backgroundColor: chipColors[index%(chipColors.length-1)] || chipColors[0]
+                    backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color
                   }
                 }}
                 label={tag} />
@@ -108,7 +96,7 @@ const Query = ({ fullWidth, queries }) => {
                         sx={{
                           lineHeight: '140%',
                           fontSize: '0.625rem',
-                          backgroundColor: chipColors[index%(chipColors.length-1)] || chipColors[0]
+                          backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color
                         }}
                         label={tag} />
                     ))}
@@ -127,7 +115,7 @@ const Query = ({ fullWidth, queries }) => {
         </Box>
 
         <Box display='flex' alignItems='center' gap={ 1.2 }>
-          <Filter />
+          <Filter facets_annotations_colors={facets_annotations_colors} />
           <Divider sx={dividerStyle} />
           <Button
             disableRipple

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/NarrowSearchFilter/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/NarrowSearchFilter/index.js
@@ -3,9 +3,9 @@ import React from "react";
 import CloseIcon from '@mui/icons-material/Close';
 import vars from "../../../theme/variables";
 
-const { searchHeadingColor, chipGreenSecondary, primaryBg, chipRedSecondary, outlinedBtnTextColor } = vars;
+const { searchHeadingColor, primaryBg, outlinedBtnTextColor } = vars;
 
-export const NarrowSearchFilter = ({groupedOptions, chipColors}) => {
+export const NarrowSearchFilter = ({groupedOptions, facets_annotations_colors}) => {
   let tags = [];
   groupedOptions?.forEach((option, index) => (
     option?.facets_annotation?.forEach( fa => { if ( !tags.find(t => t == fa )) tags.push(fa)})
@@ -51,7 +51,7 @@ export const NarrowSearchFilter = ({groupedOptions, chipColors}) => {
               sx={{
                 lineHeight: '140%',
                 fontSize: '0.625rem',
-                backgroundColor: chipColors[index%(chipColors.length-1)] || chipColors[0]
+                backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color
               }}
               label= {tag}
               onDelete={() => null}

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/NarrowSearchFilter/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/NarrowSearchFilter/index.js
@@ -51,7 +51,7 @@ export const NarrowSearchFilter = ({groupedOptions, facets_annotations_colors}) 
               sx={{
                 lineHeight: '140%',
                 fontSize: '0.625rem',
-                backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default'].color
+                backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color
               }}
               label= {tag}
               onDelete={() => null}

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/RecentSearch/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/RecentSearch/index.js
@@ -7,7 +7,7 @@ import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 const { secondaryBg, searchBoxBg, whiteColor, searchHeadingColor, listHover } = vars;
 const chips_cutoff = 3;
 
-export const RecentSearch = ({ getOptionProps, selectedFilters, recentSearches, chipColors, handleResultSelection }) => {
+export const RecentSearch = ({ getOptionProps, selectedFilters, recentSearches, facets_annotations_colors, handleResultSelection }) => {
   const hasTag = (facets_annotations) => {
     let hasTag = false;
     facets_annotations?.forEach( annotation => {
@@ -100,7 +100,7 @@ export const RecentSearch = ({ getOptionProps, selectedFilters, recentSearches, 
                       sx={{
                         lineHeight: '140%',
                         fontSize: '0.625rem',
-                        backgroundColor: chipColors[index] || chipColors[0]
+                        backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default']?.color
                       }}
                       label={tag}
                     />

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/RecentSearch/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/RecentSearch/index.js
@@ -100,7 +100,7 @@ export const RecentSearch = ({ getOptionProps, selectedFilters, recentSearches, 
                       sx={{
                         lineHeight: '140%',
                         fontSize: '0.625rem',
-                        backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default']?.color
+                        backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color
                       }}
                       label={tag}
                     />

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/RecentSearch/listItem.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/RecentSearch/listItem.js
@@ -78,7 +78,7 @@ export const Item = ({
               }}>
                 {search?.facet_annotations?.slice(2)?.map((tag, index) => <Chip key={`remaining-tag-${index}`} sx={{
                   lineHeight: '140%',
-                  fontSize: '0.625rem', backgroundColor: chipColors[tag.id]
+                  fontSize: '0.625rem', backgroundColor: facets_annotations_colors[tag.id]?.color
                 }} label={tag.label} />)}
               </Box>
             }

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
@@ -24,11 +24,6 @@ const {
   outlinedBtnTextColor,
   primaryBg,
   outlinedBtnBorderColor,
-  chipPink,
-  chipRed,
-  chipGreen,
-  chipYellow,
-  chipOrange,
   queryChipBg
 } = vars;
 
@@ -133,11 +128,11 @@ const Listbox = styled('div')(
 `,
 );
 
-const chipColors = [chipRed, chipGreen, chipOrange, chipPink, chipYellow];
-
 const searchResults = [
 
 ];
+
+const facets_annotations_colors = require("../../components/configuration/VFBColors").facets_annotations_colors;
 
 export default function SearchBuilder(props) {
 
@@ -336,7 +331,7 @@ export default function SearchBuilder(props) {
           />) : null }
 
           { recentSearch?.length >= 1 ? <RecentSearch
-            chipColors={chipColors}
+            facets_annotations_colors={facets_annotations_colors}
             recentSearches={recentSearch}
             getOptionProps={getOptionProps}
             selectedFilters={props.applyFilters}
@@ -347,7 +342,7 @@ export default function SearchBuilder(props) {
             groupedOptions={groupedOptions}
             getOptionProps={getOptionProps}
             selectedFilters={props.applyFilters}
-            chipColors={chipColors}
+            facets_annotations_colors={facets_annotations_colors}
             handleResultSelection={handleResultSelection}
           />) : <CircularProgress sx={{left: '50%', marginTop : '10%', position : 'relative'}}/> }
         </Listbox>

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchResult/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchResult/index.js
@@ -97,7 +97,7 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
                       sx={{
                         lineHeight: '140%',
                         fontSize: '0.625rem',
-                        backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default']?.color
+                        backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color
                       }}
                       label={tag}
                     />

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchResult/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchResult/index.js
@@ -4,9 +4,11 @@ import vars from "../../../theme/variables";
 import { Search } from "../../../icons";
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
+const facets_annotations_colors = require("../../../components/configuration/VFBColors").facets_annotations_colors;
+
 const { secondaryBg, searchBoxBg, whiteColor, searchHeadingColor, listHover } = vars;
 const chips_cutoff = 3;
-export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, chipColors, handleResultSelection }) => {
+export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, facets_annotations_colors, handleResultSelection }) => {
   const hasTag = (facets_annotations) => {
     let hasTag = true;
     facets_annotations?.forEach( annotation => {
@@ -95,7 +97,7 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
                       sx={{
                         lineHeight: '140%',
                         fontSize: '0.625rem',
-                        backgroundColor: chipColors[index] || chipColors[0]
+                        backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors['Default']?.color
                       }}
                       label={tag}
                     />


### PR DESCRIPTION
This is for issue VFB-137 of JIRA. Aligns chip colors with ones in production deployment (v2...). Puts color object with values in global configuration where all components can access it. Creates a Default color in configuration for when none of the tags match.


Tested manually:
- Made sure updated tags with prod colors where present in Term Info component
![image](https://github.com/MetaCell/virtual-fly-brain/assets/4562825/6b2fb1d8-bf74-41d8-940f-bb59c1b10d83)

- Made sure updated tags with prod colors where present in Search component
![image](https://github.com/MetaCell/virtual-fly-brain/assets/4562825/869ef751-0f25-424e-997f-bc70e06c6ce0)

- Made sure updated tags with prod colors where present in Query component
![image](https://github.com/MetaCell/virtual-fly-brain/assets/4562825/9beaf2d0-23dd-4690-878e-cd567ed48a87)
