### PR TITLE
Added error handling and modal

### DIFF
--- a/applications/virtual-fly-brain/client/src/components/ErrorModal.js
+++ b/applications/virtual-fly-brain/client/src/components/ErrorModal.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import Modal from '@mui/material/Modal';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  boxShadow: 24,
+  p: 4,
+  outline: 'none', 
+};
+
+const ErrorModal = ({ display, message }) => {
+  return (
+    <Modal
+      open={display}
+      onClose={() => {}}
+      aria-labelledby="error-modal-title"
+      aria-describedby="error-modal-description"
+    >
+      <Box sx={style}>
+        <Typography id="error-modal-title" variant="h6" component="h2">
+          Error
+        </Typography>
+        <Typography id="error-modal-description" sx={{ mt: 2 }}>
+          {message}
+        </Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 3 }}>
+          <Button onClick={() => {}} variant="contained" color="error">
+            Close
+          </Button>
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+export default ErrorModal;

--- a/applications/virtual-fly-brain/client/src/components/Layout.js
+++ b/applications/virtual-fly-brain/client/src/components/Layout.js
@@ -8,6 +8,7 @@ import vars from "../theme/variables";
 import VFBDownloadContents from "./VFBDownloadContents/VFBDownloadContents";
 import VFBUploader from "./VFBUploader/VFBUploader";
 import QueryBuilder from "./queryBuilder";
+import ErrorModal from "./ErrorModal";
 import { getLayoutManagerInstance } from "@metacell/geppetto-meta-client/common/layout/LayoutManager";
 import { addWidget } from '@metacell/geppetto-meta-client/common/layout/actions';
 import { threeDCanvasWidget, stackViewerWidget, roiBrowserWidget, termContextWidget, circuitBrowserWidget, listViewerWidget } from "./layout/widgets";
@@ -41,6 +42,15 @@ const MainLayout = ({ bottomNav, setBottomNav }) => {
   const launchTemplate = useSelector(state => state.instances.launchTemplate)
   const dispatch = useDispatch();
   let templateRef = window.location.origin + "?id=" + launchTemplate?.metadata?.Id;
+
+  //global reducers errors
+  const instancesError = useSelector(state => state.instances.error);
+  const instancesErrorMessage = useSelector(state => state.instances.errorMessage);
+  const queriesError = useSelector(state => state.queries.error);
+  const queriesErrorMessage = useSelector(state => state.queries.errorMessage);
+
+  const modalError = instancesError || queriesError;
+  const modalErrorMessage = instancesErrorMessage || queriesErrorMessage;
 
   useEffect(() => {
     setTab(defaultActiveTab)
@@ -156,6 +166,7 @@ const MainLayout = ({ bottomNav, setBottomNav }) => {
           </Box>
         ) : null}
       </MediaQuery>
+      <ErrorModal display={modalError} message={modalErrorMessage} />
       <Modal
         open={modalOpen}
         aria-labelledby="modal-modal-title"

--- a/applications/virtual-fly-brain/client/src/reducers/InstancesReducer.js
+++ b/applications/virtual-fly-brain/client/src/reducers/InstancesReducer.js
@@ -16,7 +16,8 @@ export const initialStateInstancesReducer = {
   event : {},
   isLoading: false,
   launchTemplate : null,
-  error: false
+  error: false,
+  errorMessage: undefined
 };
 
 const getMappedCanvasData = (loadedInstances) => {
@@ -78,12 +79,15 @@ const InstancesReducer = (state = initialStateInstancesReducer, response) => {
           stackViewerData : stackViewerData,
           focusedInstance : loadedInstances?.find( i => i?.metadata?.Id === response.payload.Id ),
           event : { action : getInstancesTypes.ADD_INSTANCE, id : response.payload.Id, trigger : Date.now()},
-          isLoading: false
+          isLoading: false,
+          error: false,
+          errorMessage: undefined
         })
       }
       case getInstancesTypes.GET_INSTANCES_FAILURE:{
         return Object.assign({}, state, {
-          error: true
+          error: true,
+          errorMessage: response.payload.error,
         })
       }
       case getInstancesTypes.REMOVE_INSTANCES_SUCCESS:{

--- a/applications/virtual-fly-brain/client/src/reducers/QueriesReducer.js
+++ b/applications/virtual-fly-brain/client/src/reducers/QueriesReducer.js
@@ -3,7 +3,8 @@ import { getQueriesTypes } from './actions/types/getQueriesTypes';
 export const initialStateQueriesReducer = {
   queries : [],
   isLoading: false,
-  error: false
+  error: false,
+  errorMessage: undefined
 };
 
 const QueriesReducer = (state = initialStateQueriesReducer, response) => {
@@ -25,11 +26,14 @@ const QueriesReducer = (state = initialStateQueriesReducer, response) => {
       case getQueriesTypes.DELETE_QUERY:
         return Object.assign({}, state, {
           queries: state.queries?.filter( i => i.short_form !== response.payload.short_form ),
-          isLoading: false
+          isLoading: false,
+          error: false,
+          errorMessage: undefined
         })
       case getQueriesTypes.GET_QUERIES_FAILURE:
         return Object.assign({}, state, {
-          error: true
+          error: true,
+          errorMessage: response.payload,
         })
      default:
         return state;


### PR DESCRIPTION
This is the implementation for the analysis: https://metacell.atlassian.net/browse/VFB-127 

Changed the application so the two main actions which pull data from the vfb_query library, would handle errors conditions when calling the REST api. For this, both QueryReducer and InstanceReducer where extended with:

 {
  error, 
  errorMessage
 }
 
 which will store the result of GET_QUERIES_FAILURE, GET_INSTANCES_FAILURE actions results.
 
 a new ErrorModal component was added to which the Layout general component will pass any error that any of these two reducer would arise.
 
 
![image](https://github.com/MetaCell/virtual-fly-brain/assets/5366927/f79ddf9c-2dbd-45be-ac8d-cc7ad32cb347)


How to test this PR: would need to force an error condition from the application running or inject an error into the library response.

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments based on CloudHarness may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [x] Tests for the relevant cases are included in this pr
- [ ] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

 