### PR TITLE
VFB-117 Search and Query tags are not all displayed

### DIFF
--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchResult/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchResult/index.js
@@ -1,8 +1,8 @@
-import { Box, Typography, Chip, Button } from "@mui/material";
+import { Box, Typography, Chip, Tooltip } from "@mui/material";
 import React from "react";
 import vars from "../../../theme/variables";
 import { Search } from "../../../icons";
-import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
+// import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
 const facets_annotations_colors = require("../../../components/configuration/VFBColors").facets_annotations_colors;
 
@@ -19,6 +19,26 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
 
     return hasTag;
   }
+
+  const renderTooltipChips = (option) => {
+    return <Box display="grid" gridTemplateColumns="auto auto" gap={0.5}>
+      {
+        option?.facets_annotation
+        .slice(chips_cutoff)
+        .map((tag, index) => (
+          <Chip
+            key={tag + index}
+            sx={{
+              lineHeight: '140%',
+              fontSize: '0.625rem',
+              backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color,
+            }}
+            label={tag}
+          />
+        ))
+      }
+    </Box>
+  };
 
   return (
     <Box sx={{
@@ -58,6 +78,7 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
               '&:hover': {
                 backgroundColor: secondaryBg,
                 cursor: 'pointer',
+                borderRadius: '0.5rem'
               }
             }}>
               <Box sx={{
@@ -104,17 +125,24 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
                 }
                 )}
                 {
-                  option?.facets_annotation?.length > 3 && <Chip sx={{
-                    lineHeight: '140%',
-                    fontSize: '0.625rem',
-                    backgroundColor: searchBoxBg
-                  }} 
-                  label={`+${option?.facets_annotation?.length - chips_cutoff}`}
-                  />
+                  option?.facets_annotation?.length > 3 && <Tooltip 
+                    title={renderTooltipChips(option)} 
+                    placement="bottom-end" 
+                    arrow
+                  >
+                    <Chip 
+                      sx={{
+                        lineHeight: '140%',
+                        fontSize: '0.625rem',
+                        backgroundColor: searchBoxBg
+                      }} 
+                      label={`+${option?.facets_annotation?.length - chips_cutoff}`}
+                    />
+                  </Tooltip>
                 }
               </Box>
 
-              <Button sx={{
+              {/* <Button sx={{
                 color: whiteColor,
                 zIndex: 9,
                 justifyContent: 'flex-end',
@@ -135,7 +163,7 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
                   fontSize: '0.75rem',
                   m: 0,
                 }} />
-              </Button>
+              </Button> */}
 
             </Box>
           </Box> : null

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchResult/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchResult/index.js
@@ -2,7 +2,6 @@ import { Box, Typography, Chip, Tooltip } from "@mui/material";
 import React from "react";
 import vars from "../../../theme/variables";
 import { Search } from "../../../icons";
-// import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 
 const facets_annotations_colors = require("../../../components/configuration/VFBColors").facets_annotations_colors;
 
@@ -21,7 +20,7 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
   }
 
   const renderTooltipChips = (option) => {
-    return <Box display="grid" gridTemplateColumns="auto auto" gap={0.5}>
+    return <>
       {
         option?.facets_annotation
         .slice(chips_cutoff)
@@ -32,12 +31,14 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
               lineHeight: '140%',
               fontSize: '0.625rem',
               backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color,
+              marginRight: '0.25rem',
+              marginBottom: '0.25rem'
             }}
             label={tag}
           />
         ))
       }
-    </Box>
+    </>
   };
 
   return (
@@ -125,7 +126,7 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
                 }
                 )}
                 {
-                  option?.facets_annotation?.length > 3 && <Tooltip 
+                  option?.facets_annotation?.length > 3 && <Tooltip
                     title={renderTooltipChips(option)} 
                     placement="bottom-end" 
                     arrow
@@ -141,30 +142,6 @@ export const SearchResult = ({ getOptionProps, selectedFilters, groupedOptions, 
                   </Tooltip>
                 }
               </Box>
-
-              {/* <Button sx={{
-                color: whiteColor,
-                zIndex: 9,
-                justifyContent: 'flex-end',
-                background: listHover,
-                borderRadius: '0.25rem',
-                width: '5.8125rem',
-                minWidth: '0.0625rem',
-                p: '0 0.75rem 0 0',
-                height: '100%',
-                position: 'absolute',
-                right: 0,
-                top: 0,
-                '&:hover': {
-                  background: listHover
-                }
-              }} variant='text'>
-                <ArrowOutwardIcon sx={{
-                  fontSize: '0.75rem',
-                  m: 0,
-                }} />
-              </Button> */}
-
             </Box>
           </Box> : null
         ))}

--- a/applications/virtual-fly-brain/client/src/theme/index.js
+++ b/applications/virtual-fly-brain/client/src/theme/index.js
@@ -761,7 +761,7 @@ theme = createTheme({
         root: {
           fontFamily: primaryFont,
           height: '1.5rem',
-          padding: '0 0.5rem',
+          padding: '0.5rem',
           fontWeight: 400,
           fontSize: '0.625rem',
           lineHeight: '133%',


### PR DESCRIPTION
Issue #VFB-117 
Problem: Search and Query tags are not all displayed
Solution: 
I used tooltip to show rest of tooltips in 'Suggested search' section.

![image](https://github.com/MetaCell/virtual-fly-brain/assets/67194168/0487f3ce-517e-4c97-803b-675ca183b03f)
