### PR TITLE
VFB-117 Search and Query tags are not all displayed

### DIFF
--- a/applications/virtual-fly-brain/client/src/shared/subHeader/RecentSearch/index.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/RecentSearch/index.js
@@ -1,4 +1,4 @@
-import { Box, Typography, Chip, Button } from "@mui/material";
+import { Box, Typography, Chip, Tooltip } from "@mui/material";
 import React from "react";
 import vars from "../../../theme/variables";
 import { Search } from "../../../icons";
@@ -18,6 +18,28 @@ export const RecentSearch = ({ getOptionProps, selectedFilters, recentSearches, 
 
     return hasTag;
   }
+
+  const renderTooltipChips = (option) => {
+    return <>
+      {
+        option?.facets_annotation
+        .slice(chips_cutoff)
+        .map((tag, index) => (
+          <Chip
+            key={tag + index}
+            sx={{
+              lineHeight: '140%',
+              fontSize: '0.625rem',
+              backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color,
+              marginRight: '0.25rem',
+              marginBottom: '0.25rem'
+            }}
+            label={tag}
+          />
+        ))
+      }
+    </>
+  };
 
   return (
     <Box sx={{
@@ -106,37 +128,21 @@ export const RecentSearch = ({ getOptionProps, selectedFilters, recentSearches, 
                     />
                 }
                 )}
-                <Chip sx={{
-                  lineHeight: '140%',
-                  fontSize: '0.625rem',
-                  backgroundColor: searchBoxBg
-                }} label={`+${option?.facets_annotation?.length - chips_cutoff}`}
-                />
-              </Box>
-
-              <Button sx={{
-                color: whiteColor,
-                zIndex: 9,
-                justifyContent: 'flex-end',
-                background: listHover,
-                borderRadius: '0.25rem',
-                width: '5.8125rem',
-                minWidth: '0.0625rem',
-                p: '0 0.75rem 0 0',
-                height: '100%',
-                position: 'absolute',
-                right: 0,
-                top: 0,
-                '&:hover': {
-                  background: listHover
+                {
+                  option?.facets_annotation?.length > 3 && <Tooltip
+                  arrow
+                  placement="bottom-end"
+                  title={renderTooltipChips(option)}
+                >
+                  <Chip sx={{
+                    lineHeight: '140%',
+                    fontSize: '0.625rem',
+                    backgroundColor: searchBoxBg
+                  }} label={`+${option?.facets_annotation?.length - chips_cutoff}`}
+                  />
+                </Tooltip>
                 }
-              }} variant='text'>
-                <ArrowOutwardIcon sx={{
-                  fontSize: '0.75rem',
-                  m: 0,
-                }} />
-              </Button>
-
+              </Box>
             </Box>
           </Box>
         ))}


### PR DESCRIPTION
Issue VFB-117
Peoblem: Search and Query tags are not all displayed
Solution: 
Recent search section hover effect is done with tooltip

![image](https://github.com/MetaCell/virtual-fly-brain/assets/67194168/77147ffe-305c-4cf5-8c4c-6302a01ff01c)
