### PR TITLE
#dev-fix  Revert webpack configuration

### DIFF
--- a/applications/virtual-fly-brain/client/webpack.config.js
+++ b/applications/virtual-fly-brain/client/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = function webpacking(envVariables) {
   }
 
   const API_URL = {
-    production: JSON.stringify('http://localhost:8080/'),
+    production: JSON.stringify('https://vfb.dev.metacell.us/'),
     development: JSON.stringify('http://localhost:8080/')
   }
   


### PR DESCRIPTION
Revert webpack configuration to use our deployment domain as our server, localhost was committed by mistake. 