### PR TITLE
VFB-168 Search component stopped expanding when on focus

### DIFF
--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
@@ -146,7 +146,6 @@ export default function SearchBuilder(props) {
   const [lastSearch, setLastSearch] = React.useState("");
   const allLoadedInstances = useSelector(state => state.instances.allLoadedInstances);
   const queries = useSelector(state => state.queries.queries);
-  const [hasFocus,setHasFocus] = React.useState(false);
   const globalRecentSearches = useSelector( state => state.globalInfo.recentSearches)
   const queriesError = useSelector(state => state.queries.error);
   const queriesErrorMessage = useSelector(state => state.queries.errorMessage);
@@ -275,7 +274,7 @@ export default function SearchBuilder(props) {
   }
 
   const handleFocused = (focused) => {
-    setHasFocus(focused)
+    props.setFocused(focused);
   }
 
   const {
@@ -347,7 +346,7 @@ export default function SearchBuilder(props) {
           <input placeholder='Find something...' {...getInputProps()}/>
         </InputWrapper>
       </Box>
-      { hasFocus && isOpen ? (
+      { props.focused && isOpen ? (
         <Listbox
           className='scrollbar'
           {...getListboxProps()}


### PR DESCRIPTION
Issue #VFB-168
Problem: Search component stopped expanding when on focus
Solution: 
Deleted hasFocus state, which I think is unnecessary, because focused state is passed as a prop and controls search expansion


https://github.com/MetaCell/virtual-fly-brain/assets/67194168/29d6cfe1-4ad1-4f3a-a506-d1a7eb0e490f

