### PR TITLE
#VFB-161 - Term Info Queries. #VFB-156 - Queries 'Apply Filters' bug. #VFB-170 - Menu History bug fix. #VFB-171 - Term Info Sections Expanded. #VFB-172 - Selection bug. #VFB-173 - Fix slice viewer 

### DIFF
--- a/applications/virtual-fly-brain/client/src/components/StackViewerComponent.js
+++ b/applications/virtual-fly-brain/client/src/components/StackViewerComponent.js
@@ -69,6 +69,18 @@ const rgbToHex = (color) => {
       };
     },
 
+    setShiftDown : function(event){
+      if(event.keyCode === 16 || event.charCode === 16){
+          window.shiftDown = true;
+      }
+    },
+
+    setShiftUp : function(event){
+      if(event.keyCode === 16 || event.charCode === 16){
+          window.shiftDown = false;
+      }
+    },
+
     /**
      * In this case, componentDidMount is used to grab the canvas container ref, and
      * and hook up the PixiJS renderer
@@ -133,21 +145,14 @@ const rgbToHex = (color) => {
 
       setTimeout(this.bufferStack, 30000);
 
-      let setShiftDown = function(event){
-          if(event.keyCode === 16 || event.charCode === 16){
-              window.shiftDown = true;
-          }
-      };
+      window.addEventListener? document.addEventListener('keydown', this.setShiftDown) : document.attachEvent('keydown', this.setShiftDown);
+      window.addEventListener? document.addEventListener('keyup', this.setShiftUp) : document.attachEvent('keyup', this.setShiftUp);
 
-      let setShiftUp = function(event){
-          if(event.keyCode === 16 || event.charCode === 16){
-              window.shiftDown = false;
-          }
-      };
+    },
 
-      window.addEventListener? document.addEventListener('keydown', setShiftDown) : document.attachEvent('keydown', setShiftDown);
-      window.addEventListener? document.addEventListener('keyup', setShiftUp) : document.attachEvent('keyup', setShiftUp);
-
+    componentWillUnmount : function () {
+      window.addEventListener? document.removeEventListener('keydown', this.setShiftDown, false) : document.attachEvent('keydown', this.setShiftDown);
+      window.addEventListener? document.removeEventListener('keyup', this.setShiftUp, false) : document.detachEvent('keyup', this.setShiftUp);
     },
 
     componentDidUpdate: function () {
@@ -441,7 +446,7 @@ const rgbToHex = (color) => {
                       var index = Number(result[j]);
                       if (i !== 0 || index !== 0) { // don't select template
                         if (index == 0 ) {
-                          if (!window.shiftDown){
+                          if ( !isSelected && (!window.shiftDown || window.shiftDown === undefined)){
                             //console.log(that.state.label[i] + ' clicked');
                             try {
                               getInstanceByID(that.props.templateDomainIds[index], true, true, true);
@@ -479,11 +484,11 @@ const rgbToHex = (color) => {
                             } else if ( !window.shiftDown || window.shiftDown === undefined ){
                               try {
                                 getInstanceByID(that.props.templateDomainTypeIds[index], false, true, false, false);
-                                that.setStatusText(that.props.templateDomainTypeIds[index] + ' selected');
+                                that.setStatusText(that.props.templateDomainNames[index] + ' selected');
                                 break;
                               } catch (ignore) {
                                 console.log(that.props.templateDomainTypeIds[index] + ' requested');
-                                that.setStatusText(that.props.templateDomainTypeIds[index] + ' requested');
+                                that.setStatusText(that.props.templateDomainNames[index] + ' requested');
                               }
                             }
                           } else {

--- a/applications/virtual-fly-brain/client/src/components/TermInfo.js
+++ b/applications/virtual-fly-brain/client/src/components/TermInfo.js
@@ -18,7 +18,7 @@ import { TreeItem } from "@mui/lab";
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import RectangleIcon from '@mui/icons-material/Rectangle';
 import GeneralInformation from "./TermInfo/GeneralInformation";
-import { getQueries } from './../reducers/actions/queries';
+import { getQueries, updateQueries } from './../reducers/actions/queries';
 import { setQueryComponentOpened } from './../reducers/actions/globals';
 import { getInstanceByID, selectInstance, hide3DMesh, hide3D, show3D, show3DMesh, removeInstanceByID,
   changeColor, show3DSkeleton, hide3DSkeleton, show3DSkeletonLines, show3DSkeletonCylinders, zoomToInstance } from './../reducers/actions/instances';
@@ -192,6 +192,7 @@ const TermInfo = ({ open, setOpen }) => {
   const [sections, setSections] = useState(["General Information", "Queries", "Graphs"])
   const data = useSelector(state => state.instances.focusedInstance)
   const allLoadedInstances = useSelector(state => state.instances.allLoadedInstances)
+  const queries = useSelector(state => state.queries.queries)
   const [termInfoData, setTermInfoData] = useState(data);
   const [ toggleReadMore, setToggleReadMore ] = useState( false );
   const dispatch = useDispatch();
@@ -291,18 +292,29 @@ const TermInfo = ({ open, setOpen }) => {
   const getQueriesLength = (queries) => {
     let queriesCount = 0;
     queries?.forEach( query => {
-      if ( query?.preview_results?.rows?.length > 0 ) {
-        queriesCount = queriesCount + 1;
+      if ( query?.count ) {
+        queriesCount = query.count + 1;
       }
     });
 
     return queriesCount;
   }
 
+  const openQuery = (id, type) => {
+    let updatedQueries = [...queries];
+    updatedQueries?.forEach( query => {
+      if( query.queries ){
+        Object.keys(query.queries)?.forEach( q => query.queries[q].active = false );
+      }
+    });
+    updateQueries(updatedQueries);
+    getQueries(id, type)
+    dispatch(setQueryComponentOpened(true));
+  }
+
   const setToggleMore = (prev, id, type) => {
     if ( !toggleReadMore ){
-      getQueries(id, type)
-      dispatch(setQueryComponentOpened(true));
+      openQuery(id, type)
     } else {
       dispatch(setQueryComponentOpened(false));
     }
@@ -607,7 +619,7 @@ const TermInfo = ({ open, setOpen }) => {
                   aria-controls="panel2a-content"
                   id="panel2a-header"
                 >
-                  <Typography>Queries ({getQueriesLength(termInfoData?.metadata?.Queries)}) </Typography>
+                  <Typography>Queries ({termInfoData?.metadata?.Queries?.length}) </Typography>
                 </AccordionSummary>
                 <AccordionDetails>
                   <TreeView
@@ -619,12 +631,12 @@ const TermInfo = ({ open, setOpen }) => {
                       <CustomBox display='flex' flexWrap='wrap'>
                         <Typography>Types of neurons with...</Typography>
                         <Box display='flex' sx={{ zIndex: 1000 }} pl={0.5}>
-                          <Typography sx={{ pr: 0.5 }}>{termInfoData?.metadata?.Queries?.reduce((n, {preview_results}) => n + preview_results?.rows?.length, 0)}</Typography>
+                          <Typography sx={{ pr: 0.5 }}>{termInfoData?.metadata?.Queries?.reduce((n, {count}) => n + count, 0)}</Typography>
                           <ListAltIcon sx={{ fontSize: '1.25rem', color: '#A0A0A0' }} />
                         </Box>
                       </CustomBox>
                     }> 
-                    { termInfoData?.metadata?.Queries?.map( query => (
+                    { termInfoData?.metadata?.Queries?.map( (query, index) => (
                          query.output_format === "table" && query?.preview_results?.rows?.length > 0 ?
                         (
                           <TreeItem key={query.label} nodeId={query.label} label={
@@ -699,7 +711,7 @@ const TermInfo = ({ open, setOpen }) => {
                                     height: 'auto',
                                     color: tabActiveColor
                                   }}>
-                                {toggleReadMore ? 'Show Less' : 'Read More'}
+                                {toggleReadMore ? 'Show Less' : 'See More'}
                               </Button>
                                 </TableContainer>
                                 </>
@@ -725,7 +737,27 @@ const TermInfo = ({ open, setOpen }) => {
                               heatLevels={ribbonConfiguration.heatLevels}
                             />
                           </Box>
-                          </TreeItem> : null)
+                          </TreeItem> : <Box
+                            display='flex'
+                            alignItems="center"
+                            key={index}
+                            onClick={() => openQuery(data.metadata?.Id, query.query)}
+                          >
+                            <Typography sx={{
+                              flexGrow: 1, color: outlinedBtnTextColor,
+                              fontSize: {
+                                xs: '0.875rem',
+                                lg: '1rem'
+                              },
+                              "&:hover": { "cursor": "pointer" } 
+                            }}>
+                              {query.label}
+                            </Typography>
+                            <Box display='flex' sx={{ zIndex: 1000 }} pl={0.5}>
+                                <Typography sx={{ pr: 0.5 }}>{termInfoData?.metadata?.Queries?.reduce((n, {count}) => n + count, 0)}</Typography>
+                                <ListAltIcon sx={{ fontSize: '1.25rem', color: '#A0A0A0' }} />
+                              </Box>
+                          </Box>)
                     ))
                   }
                     </TreeItem> : null }
@@ -752,17 +784,19 @@ const TermInfo = ({ open, setOpen }) => {
                         display='flex'
                         alignItems="center"
                         key={index}
+                        onClick={() => handleGraphSelection(data.metadata?.Id, item)}
                       >
                         <Typography sx={{
                           flexGrow: 1, color: outlinedBtnTextColor,
                           fontSize: {
                             xs: '0.875rem',
-                            lg: '1rem'
+                            lg: '1rem',
+                            "&:hover": { "cursor" : "pointer" } 
                           }
                         }}>
                           {item.label(data.metadata?.Name)}
                         </Typography>
-                        <IconButton sx={{ p: 0 }} onClick={() => handleGraphSelection(data.metadata?.Id, item)}>
+                        <IconButton sx={{ p: 0 }}>
                           <ScatterPlot />
                         </IconButton>
                       </Box>)

--- a/applications/virtual-fly-brain/client/src/components/TermInfo.js
+++ b/applications/virtual-fly-brain/client/src/components/TermInfo.js
@@ -113,7 +113,7 @@ function a11yProps(index) {
   };
 }
 const ribbonConfiguration = require("../components/configuration/TermInfo/TermInfo").ribbonConfiguration;
-
+const configuration = require("../components/configuration/TermInfo/configuration.json");
 const classes = {
   root: {
     // transition: 'all ease-in-out .3s',
@@ -188,7 +188,7 @@ const TermInfo = ({ open, setOpen }) => {
   const openMenu = Boolean(anchorEl);
   const [value, setValue] = useState(0);
   const [ displayColorPicker, setDisplayColorPicker ] = useState(false);
-  const [expanded, setExpanded] = useState({ "General Information" : false, "Queries" : false, "Graphs" : false});
+  const [expanded, setExpanded] = useState({ "General Information" : configuration.sectionsExpanded, "Queries" : configuration.sectionsExpanded, "Graphs" : configuration.sectionsExpanded});
   const [sections, setSections] = useState(["General Information", "Queries", "Graphs"])
   const data = useSelector(state => state.instances.focusedInstance)
   const allLoadedInstances = useSelector(state => state.instances.allLoadedInstances)

--- a/applications/virtual-fly-brain/client/src/components/ThreeDCanvas.js
+++ b/applications/virtual-fly-brain/client/src/components/ThreeDCanvas.js
@@ -60,9 +60,6 @@ class ThreeDCanvas extends Component {
     if(this.props.event.trigger !== prevProps.event.trigger){ 
       switch(this.props.event.action){
         // TODO : Remove and let custom camera handler control this action. Issue #VFB-136
-        case getInstancesTypes.FOCUS_INSTANCE:
-          this.canvasRef.current?.defaultCameraControlsHandler("cameraHome")
-          break;
         case getInstancesTypes.ZOOM_TO_INSTANCE : {
           let match = this.props.mappedCanvasData?.find ( inst => inst.instancePath === this.props.event.id );
           if ( match ){

--- a/applications/virtual-fly-brain/client/src/components/configuration/TermInfo/configuration.json
+++ b/applications/virtual-fly-brain/client/src/components/configuration/TermInfo/configuration.json
@@ -1,0 +1,3 @@
+{
+    "sectionsExpanded" : true
+}

--- a/applications/virtual-fly-brain/client/src/components/queryBuilder/Filter.js
+++ b/applications/virtual-fly-brain/client/src/components/queryBuilder/Filter.js
@@ -8,9 +8,13 @@ const { primaryBg, outlinedBtnTextColor, bottomNavBg, tabActiveColor, whiteColor
 const Filter = (props) => {
   const [filterAnchorEl, setFilterAnchorEl] = React.useState(null);
   const [filtersApplied, setFiltersApplied] = useState(props.tags)
-
   const filterhandleClick = (event) => {
     setFilterAnchorEl(filterAnchorEl ? null : event.currentTarget);
+  };
+
+  const applyFilters = (event) => {
+    props.setChipTags(filtersApplied)
+    filterhandleClick(event)
   };
 
   const filterOpen = Boolean(filterAnchorEl);
@@ -19,7 +23,7 @@ const Filter = (props) => {
   const handleFilterCheck = (event) => {
     let tags = [...props.tags];
     tags.find( t => t.label === event.target.name ).active = event.target.checked;
-    props.setChipTags(tags); 
+    setFiltersApplied(tags); 
   }
 
   return (
@@ -135,7 +139,7 @@ const Filter = (props) => {
             Clean all
           </Button>
           <Button
-            onClick={filterhandleClick}
+            onClick={applyFilters}
             variant="outlined"
             color="primary"
             sx={{

--- a/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
+++ b/applications/virtual-fly-brain/client/src/shared/subHeader/SearchBuilder.js
@@ -174,16 +174,14 @@ export default function SearchBuilder(props) {
       let match = value?.find( v => v.short_form === q.short_form );
       if ( match !== undefined ) {
         Object.keys(q.queries)?.forEach( key => {
-          if ( q.queries[key].active ) {
-            q.active = true;
-            if ( q.queries[key].rows === undefined ) {
-              getQueries(q.short_form, key)
-            }else { 
-              if ( !globalRecentSearches?.find( recent => recent.short_form === option.id ) && option.type){
-                dispatch(addRecentSearch(option, true));
-              }
-            }
+          q.queries[key].active = true;
+          if ( q.queries[key].rows === undefined ) {
+            getQueries(q.short_form, key)
           }
+        })
+      } else {
+        Object.keys(q.queries)?.forEach( key => {
+          q.queries[key].active = false
         })
       }
     })

--- a/applications/virtual-fly-brain/client/src/urlUpdaterMiddleware.js
+++ b/applications/virtual-fly-brain/client/src/urlUpdaterMiddleware.js
@@ -134,8 +134,8 @@ export const urlUpdaterMiddleware = store => next => (action) => {
       if ( action.payload.query?.queries?.length < 1 && action.payload.query?.rows === undefined){
         store.dispatch(getQueriesFailure("No queries found for : " + action.payload.short_form, action.payload.short_form))
       } else {
-        if ( !globalRecentSearches?.find( recent => recent.short_form === action.payload.short_form && recent.is_query) && action.payload.query.queries?.length > 0 ){
-          store.dispatch(addRecentSearch(action.payload, true));
+        if ( !globalRecentSearches?.find( recent => recent.short_form === action.payload.short_form && recent.is_query) && (action.payload.query?.rows) ){
+          store.dispatch(addRecentSearch(action.payload , true));
         }  
         if ( !firstIDLoaded ){
             store.dispatch(setFirstIDLoaded())


### PR DESCRIPTION
#VFB-161 - Add queries to Term Info. Queries were missing previously.
#VFB-156 - Fix 'Apply Filters' bug. Previously the filters were reacting whenever a chip was added or removed, now user has to click on Apply Filters.
#VFB-170 - Fix issues crashing menu history. 
#VFB-171 - Unfold all sections by default when first viewing the Term Info. Flag added to configuration for this flag.
#VFB-172 - Fix bug with selection on canvas, don't reset position
#VFB-173 - Fix bug showing ID instead of label when selecting on slice viewer


Also, it links graph link on Term Info to label and icon, previously only worked with clicking the icon


Tested locally. 