### PR TITLE
#VFB-174 Slice viewer dragging bug and #VFB-175 - Chips overflow horizontally

### DIFF
--- a/applications/virtual-fly-brain/client/src/components/StackViewerComponent.js
+++ b/applications/virtual-fly-brain/client/src/components/StackViewerComponent.js
@@ -1101,11 +1101,11 @@ const rgbToHex = (color) => {
         }
         // set the interaction data to null
         this.state.data = null;
-        this.state.dragging = false;
         this.props.setExtent({ stackX: this.stack.position.x, stackY: this.stack.position.y });
         this.createImages();
         this.state.buffer[-1].text = '';
       }
+      this.state.dragging = false;
     },
 
     onHoverEvent: function (event) {

--- a/applications/virtual-fly-brain/client/src/components/TermInfo/GeneralInformation.js
+++ b/applications/virtual-fly-brain/client/src/components/TermInfo/GeneralInformation.js
@@ -70,7 +70,7 @@ const GeneralInformation = ({data, classes}) => {
               <Typography sx={classes.heading}>Tags</Typography>
                 <Box sx={{display : 'flex', columnGap : '15px', flexWrap : 'wrap', justifyContent : 'center'}} gap={'0.288rem'}>
                   {
-                    data?.metadata?.Tags?.map((tag, i) => ( <Chip key={tag} sx={{margin: '.25rem', backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color, color: facets_annotations_colors[tag]?.textColor || facets_annotations_colors?.default?.textColor}} label={tag} /> ) )
+                    data?.metadata?.Tags?.map((tag, i) => ( <Chip key={tag} sx={{backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color, color: facets_annotations_colors[tag]?.textColor || facets_annotations_colors?.default?.textColor}} label={tag} /> ) )
                   }
               </Box>
             </Box>

--- a/applications/virtual-fly-brain/client/src/components/TermInfo/GeneralInformation.js
+++ b/applications/virtual-fly-brain/client/src/components/TermInfo/GeneralInformation.js
@@ -68,11 +68,10 @@ const GeneralInformation = ({data, classes}) => {
 
             <Box display='flex' justifyContent='space-between' columnGap={1}>
               <Typography sx={classes.heading}>Tags</Typography>
-                <Box display='flex' gap={'0.188rem'}>
+                <Box sx={{display : 'flex', columnGap : '15px', flexWrap : 'wrap', justifyContent : 'center'}} gap={'0.288rem'}>
                   {
-                    data?.metadata?.Tags?.map((tag, i) => ( <Chip key={tag} sx={{backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color, color: facets_annotations_colors[tag]?.textColor || facets_annotations_colors?.default?.textColor}} label={tag} /> ) )
+                    data?.metadata?.Tags?.map((tag, i) => ( <Chip key={tag} sx={{margin: '.25rem', backgroundColor: facets_annotations_colors[tag]?.color || facets_annotations_colors?.default?.color, color: facets_annotations_colors[tag]?.textColor || facets_annotations_colors?.default?.textColor}} label={tag} /> ) )
                   }
-                { data?.metadata?.Tags?.length > 2 && <Chip label={`+${data?.metadata?.Tags?.length - 2}`} /> }
               </Box>
             </Box>
 


### PR DESCRIPTION
This PR fixes the bug reported on #VFB-174, dragging doesn't happen anymore after mouse is up. 

Also fixes issue #VFB-175 , avoids Chips on the Term Info to overflow horizontally. 
![image](https://github.com/MetaCell/virtual-fly-brain/assets/4562825/a49720df-1379-4022-9816-a6ca1c8111ab)

![image](https://github.com/MetaCell/virtual-fly-brain/assets/4562825/68f48ace-b55d-4056-90f3-e0de1112e4d7)

