### PR TITLE
remove 'Types' case from render switch in GeneralInformation component

### DIFF
--- a/applications/virtual-fly-brain/frontend/src/components/TermInfo/GeneralInformation.jsx
+++ b/applications/virtual-fly-brain/frontend/src/components/TermInfo/GeneralInformation.jsx
@@ -878,7 +878,6 @@ const GeneralInformation = ({ data, classes, showMetadataOnly = false }) => {
       case 'Symbol':
         return renderName(value, data?.metadata?.Id);
       case 'Tags':
-      case 'Types':
         return renderTags(value);
       case 'Licenses':
         return renderLicensesList(value);


### PR DESCRIPTION
We were missing Types in the term info - Hopefully this fixes it