### PR TITLE
#VFB-227 - Apply queries grouping in the term info to the new VFB

### DIFF
--- a/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
+++ b/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
@@ -258,7 +258,7 @@ const TermInfo = ({ open, setOpen }) => {
     (state) => state.queries.queryComponentOpened
   );
   const currentTemplate = useSelector(
-    (state) => state.instances.currentTemplate
+    (state) => state.instances.launchTemplate
   );
   const [termInfoData, setTermInfoData] = useState(data);
   const [queriesData, setQueriesData] = useState(data?.metadata?.Queries);
@@ -568,7 +568,7 @@ const TermInfo = ({ open, setOpen }) => {
   }));
 
   const otherQueries = queriesData?.filter(q =>
-    !queryGroups.some(group => group.keys.some(key => q.label.startsWith(key)))
+    !queryGroups.some(group => group.keys.some(key => q?.label?.startsWith(key)))
   ) || [];
 
   // Comparator function to sort queries, moving zero-count queries to the bottom

--- a/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
+++ b/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
@@ -240,9 +240,9 @@ const TermInfo = ({ open, setOpen }) => {
   const openMenu = Boolean(anchorEl);
   const [displayColorPicker, setDisplayColorPicker] = useState(false);
   const [expanded, setExpanded] = useState({
-    "General Information": true,
-    "Queries": true,
-    "Graphs": true,
+    "General Information": configuration.sectionsExpanded,
+    "Queries": configuration.sectionsExpanded,
+    "Graphs": configuration.sectionsExpanded,
   });
   const [sections,] = useState([
     "General Information",


### PR DESCRIPTION
At the moment in the [v2.virtualflybrain.org](http://v2.virtualflybrain.org/) in the term info we have queries grouped by type, we need to implement the same grouping in the new codebase. These changes introduce those groups to this repo.

<img width="1831" height="1413" alt="term info vs term info" src="https://github.com/user-attachments/assets/51a6a41d-5476-44cf-948d-dbec51cfa9e5" />


