### PR TITLE
#VFB-227 - Apply queries grouping in the term info to the new VFB

### DIFF
--- a/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
+++ b/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
@@ -1129,7 +1129,7 @@ const TermInfo = ({ open, setOpen }) => {
                               <Typography>{group?.label}</Typography>
                               <Box display="flex" sx={{ zIndex: 6 }} pl={0.5}>
                                 <Typography sx={{ pr: 0.5 }}>
-                                  {group.queries.length}
+                                  {group.queries.reduce((n, { count }) => n + (count || 0), 0)}
                                 </Typography>
                                 <ListAltIcon
                                   sx={{ fontSize: "1.25rem", color: "#A0A0A0" }}

--- a/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
+++ b/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
@@ -566,12 +566,23 @@ const TermInfo = ({ open, setOpen }) => {
     }
   };
 
-  // Helper to check if query is a "Neurons with" query with results
-  const isNeuronsWithQuery = (q) => {
-    return q.label?.startsWith("Neurons with") && 
-           q.output_format === "table" && 
-           q?.preview_results?.rows?.length > 0;
-  };
+  const queryGroups = [
+    { label: "Types of neurons with...", keys: ["Find neurons", "Find all", "Neurons with"] },
+    { label: "Individual neurons with ", keys: ["Images of neurons with"] },
+    { label: "Tract/Nerves innervating here ", keys: ["Tracts/nerves innervating"] },
+    { label: "Lineage clones with ", keys: ["Lineage clones found"] },
+    { label: "Expression/Phenotypes found here", keys: ["Transgene expression in", "Expression patterns"] }
+  ];
+
+  // Group queries based on the configuration
+  const groupedQueries = queryGroups.map(group => ({
+    ...group,
+    queries: queriesData?.filter(q => group.keys.some(key => q.label.startsWith(key))) || []
+  }));
+
+  const otherQueries = queriesData?.filter(q =>
+    !queryGroups.some(group => group.keys.some(key => q?.label?.startsWith(key)))
+  ) || [];
 
   // Comparator function to sort queries, moving zero-count queries to the bottom
   const sortByCountDescending = (a, b) => {

--- a/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
+++ b/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
@@ -1243,7 +1243,7 @@ const TermInfo = ({ open, setOpen }) => {
                                         onClick={() =>
                                           setToggleMore(
                                             (prev) => !prev,
-                                            termInfoData.metadata?.Id,
+                                            termInfoData?.metadata?.Id,
                                             query.query
                                           )
                                         }
@@ -1256,7 +1256,7 @@ const TermInfo = ({ open, setOpen }) => {
                                           "&:hover": { background: "transparent" },
                                         }}
                                       >
-                                        {currentOpenQuery === `${termInfoData.metadata?.Id}-${query.query}` && toggleReadMore ? "Show Less" : "See More"}
+                                        {currentOpenQuery === `${termInfoData?.metadata?.Id}-${query.query}` && toggleReadMore ? "Show Less" : "See More"}
                                       </Button>
                                     }
                                   />
@@ -1472,7 +1472,7 @@ const TermInfo = ({ open, setOpen }) => {
                                       onClick={() =>
                                         setToggleMore(
                                           (prev) => !prev,
-                                          termInfoData.metadata?.Id,
+                                          termInfoData?.metadata?.Id,
                                           query.query
                                         )
                                       }
@@ -1485,7 +1485,7 @@ const TermInfo = ({ open, setOpen }) => {
                                         "&:hover": { background: "transparent" },
                                       }}
                                     >
-                                      {currentOpenQuery === `${termInfoData.metadata?.Id}-${query.query}` && toggleReadMore ? "Show Less" : "See More"}
+                                      {currentOpenQuery === `${termInfoData?.metadata?.Id}-${query.query}` && toggleReadMore ? "Show Less" : "See More"}
                                     </Button>
                                   }
                                 />

--- a/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
+++ b/applications/virtual-fly-brain/frontend/src/components/TermInfo.jsx
@@ -254,7 +254,7 @@ const TermInfo = ({ open, setOpen }) => {
   );
   const queries = useSelector((state) => state.queries.queries);
   const queryComponentOpened = useSelector(
-    (state) => state.queries.queryComponentOpened
+    (state) => state.globalInfo.queryComponentOpened
   );
   const [queriesData, setQueriesData] = useState(data?.metadata?.Queries || []);
   const currentTemplate = useSelector(
@@ -577,7 +577,7 @@ const TermInfo = ({ open, setOpen }) => {
   // Group queries based on the configuration
   const groupedQueries = queryGroups.map(group => ({
     ...group,
-    queries: queriesData?.filter(q => group.keys.some(key => q.label.startsWith(key))) || []
+    queries: queriesData?.filter(q => group.keys.some(key => q?.label?.startsWith(key))) || []
   }));
 
   const otherQueries = queriesData?.filter(q =>
@@ -1110,8 +1110,8 @@ const TermInfo = ({ open, setOpen }) => {
                 <AccordionDetails>
                   <SimpleTreeView
                     aria-label="customized"
-                    defaultExpandIcon={<ArrowDown />}
-                    defaultCollapseIcon={<ArrowRight />}
+                    defaultExpandIcon={<ArrowRight />}
+                    defaultCollapseIcon={<ArrowDown />}
                   >
                     {/* Group queries that start with "Neurons with" */}
                     {groupedQueries.map((group, groupIndex) => (
@@ -1134,7 +1134,7 @@ const TermInfo = ({ open, setOpen }) => {
                             </CustomBox>
                           }
                         >
-                          {group.queries.map((query, index) => {
+                          {group.queries.slice().sort(sortByCountDescending).map((query, index) => {
                               const headers = getOrderedHeaders(query?.preview_results?.headers);
                               return (query.output_format === "table" &&
                                 query?.preview_results?.rows?.length > 0 ? (
@@ -1196,7 +1196,7 @@ const TermInfo = ({ open, setOpen }) => {
                                                         <Button
                                                           variant="text"
                                                           color="error"
-                                                          onClick={() => deleteId(row.id)}
+                                                          onClick={() => deleteId()}
                                                         >
                                                           Delete
                                                         </Button>
@@ -1261,7 +1261,7 @@ const TermInfo = ({ open, setOpen }) => {
                                 <TreeItem
                                   sx={{ "paddingLeft": "1.25rem" }}
                                   key={query.label}
-                                  itemId={`query-${index}`}
+                                  itemId={`ribbon-query-${groupIndex}-${index}`}
                                   label={
                                     <CustomBox display="flex" flexWrap="wrap">
                                       <Typography>{query.label}</Typography>
@@ -1330,10 +1330,7 @@ const TermInfo = ({ open, setOpen }) => {
                                     pl={0.5}
                                   >
                                     <Typography sx={{ pr: 0.5 }}>
-                                      {termInfoData?.metadata?.Queries?.reduce(
-                                        (n, { count }) => n + count,
-                                        0
-                                      )}
+                                      {query?.count ?? query?.preview_results?.rows?.length ?? 0}
                                     </Typography>
                                     <ListAltIcon
                                       sx={{ fontSize: "1.25rem", color: "#A0A0A0" }}
@@ -1373,7 +1370,7 @@ const TermInfo = ({ open, setOpen }) => {
                               <TreeItem
                                 sx={{ "paddingLeft": "1.25rem" }}
                                 key={query.label + index}
-                                itemId={`query-root-${index}`}
+                                itemId={`table-query-root-${index}`}
                                 label={
                                   <CustomBox display="flex" flexWrap="wrap">
                                     <Typography>{query.label}</Typography>
@@ -1428,7 +1425,7 @@ const TermInfo = ({ open, setOpen }) => {
                                                       <Button
                                                         variant="text"
                                                         color="error"
-                                                        onClick={() => deleteId(row.id)}
+                                                        onClick={() => deleteId()}
                                                       >
                                                         Delete
                                                       </Button>
@@ -1493,7 +1490,7 @@ const TermInfo = ({ open, setOpen }) => {
                               <TreeItem
                                 sx={{ "paddingLeft": "1.25rem" }}
                                 key={query.label}
-                                itemId={`query-root-${index}`}
+                                itemId={`ribbon-query-root-${index}`}
                                 label={
                                   <CustomBox display="flex" flexWrap="wrap">
                                     <Typography>{query.label}</Typography>


### PR DESCRIPTION
Update term info queries section to display queries grouped as in v2 version of vfb. Keeps displaying inner Table of preview of queries when expanding a query. For those queries who are not part of a group, they get place under Other Queries. This last part is a bit of a change from v2.virtualflybrain, as those leaf queries where groupless there, whereas in dev we have a new group call Other Queries where these leafless queries can be placed as in screenshot and this branch. @ddelpiano 

<img width="1675" height="1368" alt="v2 vs dev2" src="https://github.com/user-attachments/assets/8fd6ff19-5bcc-41f9-88a6-fcd17602c411" />
<img width="1704" height="1463" alt="V2 vs dev " src="https://github.com/user-attachments/assets/c6dfb568-8bd8-4249-bea5-7abcdbe62534" />



This pull request refactors and enhances the way queries are grouped and displayed in the `TermInfo` component. The main changes include introducing configurable query groupings, improving state management for queries data, and updating the UI to reflect these new groupings for a more organized and scalable presentation.

**Query grouping and UI improvements:**

* Introduced a `queryGroups` configuration to categorize queries by label prefixes, and created logic to group queries accordingly, making it easier to manage and extend groupings in the future.
* Updated the rendering logic in the `SimpleTreeView` to iterate over these groups, displaying each group and its queries in a structured way. The "Other queries" section now cleanly displays any queries not matching the predefined groups. [[1]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L1099-R1128) [[2]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L1120-R1144) [[3]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L1332-R1349) [[4]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L1344-R1358) [[5]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L1355-R1367)

**State management enhancements:**

* Added a `queriesData` state to manage queries independently of the main `termInfoData`, ensuring that updates to the data prop are reflected in both pieces of state. [[1]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L257-L260) [[2]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71R497)

**UI consistency and accessibility:**

* Updated tree item keys and IDs to include group and index information, improving React key uniqueness and accessibility. [[1]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L1120-R1144) [[2]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L1153-R1167) [[3]](diffhunk://#diff-69a2e0bcca225e5ccff7b89eb911219cc5287b6fbf5dce3cc6184ffaf0531e71L1222-R1236)

**Minor UI tweaks:**

* Changed default icons for expand/collapse in `SimpleTreeView` for better clarity.