### PR TITLE
#VFB-231 - Replace the /new endpoint with /embed

### DIFF
--- a/applications/virtual-fly-brain/frontend/src/components/NeuroglassViewer.jsx
+++ b/applications/virtual-fly-brain/frontend/src/components/NeuroglassViewer.jsx
@@ -25,7 +25,7 @@ export default function NeuroglassViewer() {
       layout,
     );
     if (!state || !NEUROGLASS_URL) return '';
-    return `${NEUROGLASS_URL}/new#!${encodeURIComponent(JSON.stringify(state))}`;
+    return `${NEUROGLASS_URL}/embed#!${encodeURIComponent(JSON.stringify(state))}`;
   }, [allLoadedInstances, focusedInstance?.metadata?.Id, neuroglassView, isMobile]);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request makes a small update to the `NeuroglassViewer` component. The change modifies the URL used for embedding, switching from the `/new` endpoint to the `/embed` endpoint. This after introduction of /embed endpoint in Neuroglass to allow embedding it without headers https://metacell.atlassian.net/browse/NGLASS-1554

<img width="461" height="441" alt="Screenshot 2026-04-14 at 11 04 39 PM" src="https://github.com/user-attachments/assets/03f0a0cf-c530-4076-9218-aa383ab29b7d" />
